### PR TITLE
merge changes from monero (2019.09.05)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@
 
 ANDROID_STANDALONE_TOOLCHAIN_PATH ?= /usr/local/toolchain
 
+dotgit=$(shell ls -d .git/config)
+ifneq ($(dotgit), .git/config)
+  USE_SINGLE_BUILDDIR=1
+endif
+
 subbuilddir:=$(shell echo  `uname | sed -e 's|[:/\\ \(\)]|_|g'`/`git branch | grep '\* ' | cut -f2- -d' '| sed -e 's|[:/\\ \(\)]|_|g'`)
 ifeq ($(USE_SINGLE_BUILDDIR),)
   builddir := build/"$(subbuilddir)"

--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -353,13 +353,13 @@ eof:
           std::string command;
           bool get_line_ret = m_stdin_reader.get_line(command);
           if (!m_running)
-          break;
-        if (m_stdin_reader.eos())
-        {
-          MGINFO("EOF on stdin, exiting");
-          break;
-        }
-        if (!get_line_ret)
+            break;
+          if (m_stdin_reader.eos())
+          {
+            MGINFO("EOF on stdin, exiting");
+            break;
+          }
+          if (!get_line_ret)
           {
             MERROR("Failed to read line.");
           }

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -201,7 +201,7 @@ namespace cryptonote
         float hr = static_cast<float>(total_hr)/static_cast<float>(m_last_hash_rates.size());
         const auto flags = std::cout.flags();
         const auto precision = std::cout.precision();
-        std::cout << "hashrate: " << std::setprecision(4) << std::fixed << hr << flags << precision << ENDL;
+        std::cout << "hashrate: " << std::setprecision(4) << std::fixed << hr << std::setiosflags(flags) << std::setprecision(precision) << ENDL;
       }
     }
     m_last_hr_merge_time = misc_utils::get_tick_count();

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -306,6 +306,9 @@ uint64_t Blockchain::get_current_blockchain_height() const
 bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline, const cryptonote::test_options *test_options, difficulty_type fixed_difficulty)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
+
+  CHECK_AND_ASSERT_MES(nettype != FAKECHAIN || test_options, false, "fake chain network type used without options");
+
   CRITICAL_REGION_LOCAL(m_tx_pool);
   CRITICAL_REGION_LOCAL1(m_blockchain_lock);
 

--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -67,7 +67,7 @@ class classname \
 // NOTE: when using a type with multiple template parameters,
 // replace any comma in the template specifier with the macro
 // above, or the preprocessor will eat the comma in a bad way.
-#define RPC_MESSAGE_MEMBER(type, name) type name;
+#define RPC_MESSAGE_MEMBER(type, name) type name = type{}
 
 
 namespace cryptonote

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -37,6 +37,8 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include "include_base_utils.h"
 using namespace epee;
 
@@ -6991,6 +6993,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
           LOG_PRINT_L1("Selecting real output: " << td.m_global_output_index << " for " << print_money(amount));
         }
 
+        std::unordered_map<const char*, std::set<uint64_t>> picks;
+
         // while we still need more mixins
         uint64_t num_usable_outs = num_outs;
         bool allow_blackballed = false;
@@ -7089,10 +7093,14 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
           }
           seen_indices.emplace(i);
 
-          LOG_PRINT_L2("picking " << i << " as " << type);
+          picks[type].insert(i);
           req.outputs.push_back({amount, i});
           ++num_found;
         }
+
+        for (const auto &pick: picks)
+          MDEBUG("picking " << pick.first << " outputs: " <<
+              boost::join(pick.second | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
 
         // if we had enough unusable outputs, we might fall off here and still
         // have too few outputs, so we stuff with one to keep counts good, and
@@ -7109,8 +7117,15 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
           [](const get_outputs_out &a, const get_outputs_out &b) { return a.index < b.index; });
     }
 
-    for (auto i: req.outputs)
-      LOG_PRINT_L1("asking for output " << i.index << " for " << print_money(i.amount));
+    if (ELPP->vRegistry()->allowed(el::Level::Debug, MONERO_DEFAULT_LOG_CATEGORY))
+    {
+      std::map<uint64_t, std::set<uint64_t>> outs;
+      for (const auto &i: req.outputs)
+        outs[i.amount].insert(i.index);
+      for (const auto &o: outs)
+        MDEBUG("asking for outputs with amount " << print_money(o.first) << ": " <<
+            boost::join(o.second | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
+    }
 
     // get the keys for those
     m_daemon_rpc_mutex.lock();

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -123,3 +123,7 @@ SET_PROPERTY(SOURCE memwipe.cpp PROPERTY COMPILE_FLAGS -Ofast)
 add_test(
   NAME    unit_tests
   COMMAND unit_tests --data-dir "${TEST_DATA_DIR}")
+
+add_executable(test_notifier test_notifier.cpp)
+target_link_libraries(test_notifier ${EXTRA_LIBRARIES})
+set_property(TARGET test_notifier PROPERTY FOLDER "tests")

--- a/tests/unit_tests/aligned.cpp
+++ b/tests/unit_tests/aligned.cpp
@@ -84,3 +84,24 @@ TEST(aligned, contents_smaller)
   aligned_free(ptr2);
 }
 
+TEST(aligned, alignment)
+{
+  static const size_t good_alignments[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+  for (size_t a = 0; a <= 8192; ++a)
+  {
+    bool good = false;
+    for (const auto t: good_alignments) if (a == t) good = true;
+    void *ptr = aligned_malloc(1, a);
+    if (good)
+    {
+      ASSERT_TRUE(ptr != NULL);
+      aligned_free(ptr);
+    }
+    else
+    {
+      ASSERT_TRUE(ptr == NULL);
+    }
+  }
+
+  ASSERT_TRUE(aligned_malloc(1, ~0) == NULL);
+}


### PR DESCRIPTION
Merging the following commits:

- console_handler: add a global log when exiting via EOF (d3cda5ad393098235637d8a5f8fa52cac96358df)
- wallet2: make fake out selection messages less spammy (92a0827eea45d06729d78fd3013c007829903f60)
- unit_tests: add unit test for alloc alignment being a power of 2 (6653062e6135e37fd36d81c575e70ef33b02609b)
- blockchain: add check test options are given for fakechain mode (a39c0358466e3816885ea0786b3a0e997fdde673)
- miner: really reset flags/precision on std::cout (6ca00b6d75fbd4a06456e23e5982e72ca8e5ba17)
- rpc: blanket initialize 0MQ request and response structures (f5f7c2ac245523b5a78a9aff57f05077ff352c1f)
- unit_tests: fix notify test when run from make *test (11415128118396a8e99774f4c9cc4aafbf319c53)
- Makefile: fix building without a git tree (9168fc9f78c1276c986c7effd63ba4f258417fd9)

See individual commit mssages for more details.