### PR TITLE
merge fix from monero: simplewallet (PR #4547)

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7045,12 +7045,6 @@ bool simple_wallet::run()
 void simple_wallet::stop()
 {
   m_cmd_binder.stop_handling();
-
-  m_idle_run.store(false, std::memory_order_relaxed);
-  m_wallet->stop();
-  // make the background refresh thread quit
-  boost::unique_lock<boost::mutex> lock(m_idle_mutex);
-  m_idle_cond.notify_one();
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector<std::string>()*/)


### PR DESCRIPTION
Merge fix from the following commit:

- simplewallet: fixed deadlock if a user hits CTRL+C twice (f2c2c47a4ba40a00d5c6b9d7ea3df4c6cb654c83) *PR #4547*

See individual commit messages for more details.