### PR TITLE
merge changes from monero: epee (PR #4573)

### DIFF
--- a/contrib/epee/include/readline_buffer.h
+++ b/contrib/epee/include/readline_buffer.h
@@ -27,6 +27,7 @@ namespace rdln
 
   private:
     std::streambuf* m_cout_buf;
+    size_t m_prompt_length;
     static std::vector<std::string>& completion_commands();
   };
   

--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -44,7 +44,7 @@ std::vector<std::string>& rdln::readline_buffer::completion_commands()
 }
 
 rdln::readline_buffer::readline_buffer()
-: std::stringbuf(), m_cout_buf(NULL)
+: std::stringbuf(), m_cout_buf(NULL), m_prompt_length(0)
 {
   current = this;
 }
@@ -86,8 +86,11 @@ void rdln::readline_buffer::set_prompt(const std::string& prompt)
   if(m_cout_buf == NULL)
     return;
   boost::lock_guard<boost::mutex> lock(sync_mutex);
+  rl_set_prompt(std::string(m_prompt_length, ' ').c_str());
+  rl_redisplay();
   rl_set_prompt(prompt.c_str());
   rl_redisplay();
+  m_prompt_length = prompt.size();
 }
 
 void rdln::readline_buffer::add_completion(const std::string& command)


### PR DESCRIPTION
Merging the following commits:

- readline_buffer: fix "cursor in prompt" bug (8f3c79374900ca77c126976036290d10f9999598)

See individual commit messages for more details.