### PR TITLE
merge changes from monero: wallet (PR #4552, PR#4561)

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5616,6 +5616,10 @@ bool wallet2::sign_tx(unsigned_tx_set &exported_txs, std::vector<wallet2::pendin
     ptx.construction_data = sd;
 
     txs.push_back(ptx);
+
+    // add tx keys only to ptx
+    txs.back().tx_key = tx_key;
+    txs.back().additional_tx_keys = additional_tx_keys;
   }
 
   // add key images

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10588,7 +10588,7 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
         + boost::lexical_cast<std::string>(signed_key_images.size()) + ", key image " + epee::string_tools::pod_to_hex(key_image));
 
     THROW_WALLET_EXCEPTION_IF(!crypto::check_ring_signature((const crypto::hash&)key_image, key_image, pkeys, &signature),
-        error::wallet_internal_error, "Signature check failed: input " + boost::lexical_cast<std::string>(n) + "/"
+        error::signature_check_failed, boost::lexical_cast<std::string>(n) + "/"
         + boost::lexical_cast<std::string>(signed_key_images.size()) + ", key image " + epee::string_tools::pod_to_hex(key_image)
         + ", signature " + epee::string_tools::pod_to_hex(signature) + ", pubkey " + epee::string_tools::pod_to_hex(*pkeys[0]));
 

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -73,6 +73,7 @@ namespace tools
     //         tx_parse_error
     //         get_tx_pool_error
     //         out_of_hashchain_bounds_error
+    //       signature_check_failed
     //       transfer_error *
     //         get_outs_general_error
     //         not_enough_unlocked_money
@@ -417,6 +418,14 @@ namespace tools
       }
 
       std::string to_string() const { return refresh_error::to_string(); }
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct signature_check_failed : public wallet_logic_error
+    {
+      explicit signature_check_failed(std::string&& loc, const std::string& message)
+        : wallet_logic_error(std::move(loc), "Signature check failed " + message)
+      {
+      }
     };
     //----------------------------------------------------------------------------------------------------
     struct transfer_error : public wallet_logic_error

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -982,6 +982,8 @@ namespace tools
     for (auto &ptx: ptxs)
     {
       res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
+      if (req.get_tx_keys)
+        res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key));
     }
 
     if (req.export_raw)

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2914,6 +2914,11 @@ namespace tools
       er.code = WALLET_RPC_ERROR_CODE_ADDRESS_INDEX_OUT_OF_BOUNDS;
       er.message = e.what();
     }
+    catch (const error::signature_check_failed& e)
+    {
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
+        er.message = e.what();
+    }
     catch (const std::exception& e)
     {
       er.code = default_error_code;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -538,10 +538,12 @@ namespace wallet_rpc
     {
       std::string unsigned_txset;
       bool export_raw;
+      bool get_tx_keys;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(unsigned_txset)
         KV_SERIALIZE_OPT(export_raw, false)
+        KV_SERIALIZE_OPT(get_tx_keys, false)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -550,11 +552,13 @@ namespace wallet_rpc
       std::string signed_txset;
       std::list<std::string> tx_hash_list;
       std::list<std::string> tx_raw_list;
+      std::list<std::string> tx_key_list;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(signed_txset)
         KV_SERIALIZE(tx_hash_list)
         KV_SERIALIZE(tx_raw_list)
+        KV_SERIALIZE(tx_key_list)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
Merging the following commits:

- wallet_rpc_server: optionally return tx keys in sign_transfer (67e76aa) PR #4552
- Return appropriate RPC error code when key image signature check fails (04ddf02) PR #4561

See individual commit messages for more details