### PR TITLE
Use URL for old releases - libsodium

### DIFF
--- a/contrib/depends/packages/sodium-darwin.mk
+++ b/contrib/depends/packages/sodium-darwin.mk
@@ -1,6 +1,6 @@
 package=sodium-darwin
 $(package)_version=1.0.15
-$(package)_download_path=https://download.libsodium.org/libsodium/releases/
+$(package)_download_path=https://download.libsodium.org/libsodium/releases/old/
 $(package)_file_name=libsodium-$($(package)_version).tar.gz
 $(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
 

--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -1,6 +1,6 @@
 package=sodium
 $(package)_version=1.0.15
-$(package)_download_path=https://download.libsodium.org/libsodium/releases/
+$(package)_download_path=https://download.libsodium.org/libsodium/releases/old/
 $(package)_file_name=libsodium-$($(package)_version).tar.gz
 $(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
 $(package)_patches=fix-whitespace.patch


### PR DESCRIPTION
Packages for the 1.0.15 version of libsodium was moved to a different URL. A download error will be encountered when running a build using gitian if this URL is not updated to point to the path where the _"old"_ versions are being served.

Note that an alternative to this would be to bump the version, at least to 1.0.16 - this is still in the non-*old* URL.