### PR TITLE
merge changes from monero: coverity fixes (PR #4617)

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -545,7 +545,7 @@ public:
   /**
    * @brief An empty constructor.
    */
-  BlockchainDB(): m_open(false) { }
+  BlockchainDB(): m_hardfork(NULL), m_open(false) { }
 
   /**
    * @brief An empty destructor.

--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -137,6 +137,7 @@ DISABLE_VS_WARNINGS(4244 4345)
   void account_base::set_null()
   {
     m_keys = account_keys();
+    m_creation_timestamp = 0;
   }
   //-----------------------------------------------------------------
   void account_base::forget_spend_key()

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -783,9 +783,6 @@ namespace cryptonote
       std::string tx_as_hex;
       bool do_not_relay;
 
-      request() {}
-      explicit request(const transaction &);
-
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_as_hex)
         KV_SERIALIZE_OPT(do_not_relay, false)

--- a/src/rpc/message.h
+++ b/src/rpc/message.h
@@ -66,7 +66,7 @@ namespace rpc
       static const char* STATUS_BAD_REQUEST;
       static const char* STATUS_BAD_JSON;
 
-      Message() : status(STATUS_OK) { }
+      Message() : status(STATUS_OK), rpc_version(0) { }
 
       virtual ~Message() { }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -814,6 +814,7 @@ wallet_keys_unlocker::~wallet_keys_unlocker()
 wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended):
   m_multisig_rescan_info(NULL),
   m_multisig_rescan_k(NULL),
+  m_upper_transaction_weight_limit(0),
   m_run(true),
   m_callback(0),
   m_trusted_daemon(false),
@@ -846,6 +847,9 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended):
   m_is_initialized(false),
   m_kdf_rounds(kdf_rounds),
   is_old_file_format(false),
+  m_watch_only(false),
+  m_multisig(false),
+  m_multisig_threshold(0),
   m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex),
   m_subaddress_lookahead_major(SUBADDRESS_LOOKAHEAD_MAJOR),
   m_subaddress_lookahead_minor(SUBADDRESS_LOOKAHEAD_MINOR),


### PR DESCRIPTION
Merging the following commits:

- blockchain_db: initialize m_hardfork in ctor just in case (blockchain_db: initialize m_hardfork in ctor just in case)
- wallet2: initialize some scalar fields in ctor where appropriate (32123789129372f1a4cb46a8aa289843e15a4b37)
- account: init creation timestamp to 0 (7cc39845be1cfa9286dec589d4f1c94381b140d9)
- rpc: remove unused ctors (bfa2dce171e2a04096c07f204037ccd13dc2fae6)
- rpc: init m_rpc_version in Message ctor (3ffbec1556f8817cb014fcea83bccc41747cfcf5)

See individual commit messages for details.