### PR TITLE
merge changes from monero: device (PR #4672)

### DIFF
--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2017-2018, uPlexa Team
 // Copyright (c) 2017-2018, The Monero Project
 // 
 // All rights reserved.

--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -1,3 +1,18 @@
+// Copyright (c) 2017-2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
 //


### PR DESCRIPTION
Merging the following commits:

- device_io_hid.cpp: fix copyright header (62f94e1b9d10ba94228bf772b30ac08798b41d95)

See individual commit message for details.

**Note:** additional commit made to include _uPlexa Team_ in the Copyright update - same as the copyright format as the _.cpp_ file that uses this header.