### PR TITLE
merge changes from monero: ringct (PR #4663)

### DIFF
--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -86,7 +86,7 @@ namespace hw {
 
     public:
 
-        device()  {}
+        device(): mode(NONE)  {}
         device(const device &hwdev) {}
         virtual ~device()   {}
 
@@ -116,7 +116,8 @@ namespace hw {
         virtual bool connect(void) = 0;
         virtual bool disconnect(void) = 0;
 
-        virtual bool set_mode(device_mode mode) = 0;
+        virtual bool set_mode(device_mode mode) { this->mode = mode; return true; }
+        virtual device_mode get_mode() const { return mode; }
 
         virtual device_type get_type() const = 0;
 
@@ -203,6 +204,9 @@ namespace hw {
         virtual bool  mlsag_sign(const rct::key &c, const rct::keyV &xx, const rct::keyV &alpha, const size_t rows, const size_t dsRows, rct::keyV &ss) = 0;
 
         virtual bool  close_tx(void) = 0;
+
+    protected:
+        device_mode mode;
     } ;
 
     struct reset_mode {

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -84,7 +84,7 @@ namespace hw {
         }
 
         bool  device_default::set_mode(device_mode mode) {
-            return true;
+            return device::set_mode(mode);
         }
 
         /* ======================================================================= */

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -397,7 +397,7 @@ namespace hw {
            CHECK_AND_ASSERT_THROW_MES(false, " device_ledger::set_mode(unsigned int mode): invalid mode: "<<mode);
         }
         MDEBUG("Switch to mode: " <<mode);
-        return true;
+        return device::set_mode(mode);
     }
 
 


### PR DESCRIPTION
Merging the following commit:
- ringct: use dummy bulletproofs when in fake mode, for speed (d6937e373b32628fff414c7d8a07e4323593c6a0 )

See commit message for details.