### PR TITLE
fix build error in tx_pool.cpp

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -382,7 +382,7 @@ namespace cryptonote
         MINFO("Pruning tx " << txid << " from txpool: weight: " << meta.weight << ", fee/byte: " << it->first.first);
         m_blockchain.remove_txpool_tx(txid);
         m_txpool_weight -= meta.weight;
-        remove_transaction_keyimages(tx, txid);
+        remove_transaction_keyimages(tx);
         MINFO("Pruned tx " << txid << " from txpool: weight: " << meta.weight << ", fee/byte: " << it->first.first);
         m_txs_by_fee_and_receive_time.erase(it--);
         changed = true;


### PR DESCRIPTION
- current remove_transaction_keyimages() implementation has only one
parameter.
- the issue was introduced in uplexa PR #62
- original Monero commit: 5a2e54a1cb184b4aeca68ce275f169a1f17e8614, PR #4688