### PR TITLE
merge changes from monero: mnemonics (PR #4684)

### DIFF
--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -216,7 +216,7 @@ namespace
     }
     boost::crc_32_type result;
     result.process_bytes(trimmed_words.data(), trimmed_words.length());
-    return result.checksum() % crypto::ElectrumWords::seed_length;
+    return result.checksum() % word_list.size();
   }
 
   /*!


### PR DESCRIPTION
Merging changes from the following commit:
- mnemonics/electrum-words/create_checksum_index(): updated to work wit…h non fixed word list length mnemonic (4a003bb5a2c45332d2c21830d6ff9ffa3c183739)

See commit message for details.