### PR TITLE
Fix boost 1.70 compliation (again)

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -414,7 +414,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
       //if no handlers were called
       //TODO: Maybe we need to have have critical section + event + callback to upper protocol to
       //ask it inside(!) critical region if we still able to go in event wait...
-      size_t cnt = socket_.get_io_service().poll_one();     
+      size_t cnt = GET_IO_SERVICE(socket_).poll_one();
       if(!cnt)
         misc_utils::sleep_no_w(1);
     }


### PR DESCRIPTION
This PR just remerges fixes for compilation with boost 1.70.

Working with GCC 8 on Ubuntu 20.04.